### PR TITLE
Fixes compilation errors on 1.0(?).

### DIFF
--- a/src/flippy.nim
+++ b/src/flippy.nim
@@ -909,7 +909,7 @@ proc outlineBorder*(image: Image, borderPx: int): Image =
       for bx in -borderPx .. borderPx:
         for by in -borderPx .. borderPx:
           var rgba = image.getRgbaSafe(x + bx - borderPx, y - by - borderPx)
-          if rgba.a > 0:
+          if rgba.a > 0.uint8:
             filled = true
             break
         if filled:


### PR DESCRIPTION
Without this I was seeing when compiling my project on 1.0.6. 

```
C:\Users\morfe\other_projects\flippy\src\flippy.nim(912, 21) Error: type mismatch: got <int literal(0), uint8>
but expected one of:
proc `<`(x, y: int64): bool
  first type mismatch at position: 2
  required type for y: int64
  but expression 'rgba.a' is of type: uint8
proc `<`[T: SomeUnsignedInt](x, y: T): bool
  first type mismatch at position: 2
  required type for y: T: SomeUnsignedInt
  but expression 'rgba.a' is of type: uint8
proc `<`(x, y: float): bool
  first type mismatch at position: 2
  required type for y: float
  but expression 'rgba.a' is of type: uint8
proc `<`(x, y: int): bool
  first type mismatch at position: 2
  required type for y: int
  but expression 'rgba.a' is of type: uint8
proc `<`(x, y: int8): bool
  first type mismatch at position: 2
  required type for y: int8
  but expression 'rgba.a' is of type: uint8
proc `<`(x, y: int16): bool
  first type mismatch at position: 2
  required type for y: int16
  but expression 'rgba.a' is of type: uint8
proc `<`(x, y: int32): bool
  first type mismatch at position: 2
  required type for y: int32
  but expression 'rgba.a' is of type: uint8
proc `<`(x, y: float32): bool
  first type mismatch at position: 2
  required type for y: float32
  but expression 'rgba.a' is of type: uint8
proc `<`[T](x: Ordinal[T]): T
  first type mismatch at position: 2
  extra argument given
9 other mismatching symbols have been suppressed; compile with --showAllMismatches:on to see them
```